### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/AlfredApp_2.x/Fast-User-Switching/README.md
+++ b/AlfredApp_2.x/Fast-User-Switching/README.md
@@ -1,4 +1,4 @@
-##Fast User Switching - Alfred Workflow
+## Fast User Switching - Alfred Workflow
 
 Switch to another User Account or go the Login Window - without moving your fingers from you keyboard!
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-##Alfred.app Workflows and Extensions
+## Alfred.app Workflows and Extensions
 
 Alfred is a productivity application for Mac OS X, which aims to save you time in searching your local computer and the web. With the Powerpack, a set of incredibly powerful features built on top of the robust core of Alfred, you can add functionality with third-party extensions. Here you can find some of my Alfred workflows and extensions. 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
